### PR TITLE
Set {{version}} in the patched release schema to the correct OCDS version

### DIFF
--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -3,7 +3,7 @@
 
 # The following lines are updated based on the `repos:dependencies` task in standard-maintenance-scripts.
 
--e git+https://github.com/open-contracting/documentation-support.git@ba8e7495da04a43bdb4ec264394868305a753075#egg=ocdsdocumentationsupport
+-e git+https://github.com/open-contracting/documentation-support.git@0cff110632d420c52e5c3e42d9a94e3a2114a106#egg=ocdsdocumentationsupport
 -e git+https://github.com/open-contracting/sphinxcontrib-opencontracting.git@e5cbb9e966bc695a525cfec5059bef692bc540a3#egg=sphinxcontrib-opencontracting
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@5e2ee024fa6a1c1ae98ec0ab6e0698f8afa0489c#egg=sphinxcontrib-jsonschema
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib-opendataservices

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,8 @@ gettext_compact = False
 gettext_domain_prefix = 'ppp-'
 
 # The version of OCDS to patch.
-standard_version = '1__1__3'
+standard_tag = '1__1__3'
+standard_version = '1.1'
 
 # List the extension identifiers and versions that should be part of this profile. The extensions must be available in
 # the extension registry: https://github.com/open-contracting/extension_registry/blob/master/extension_versions.csv

--- a/schema/build-profile.py
+++ b/schema/build-profile.py
@@ -9,6 +9,6 @@ from ocdsdocumentationsupport import build_profile
 basedir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(basedir, '..', 'docs'))
 
-from conf import standard_version, extension_versions  # noqa
+from conf import standard_tag, standard_version, extension_versions  # noqa
 
-build_profile(basedir, standard_version, extension_versions)
+build_profile(basedir, standard_tag, standard_version, extension_versions)

--- a/schema/patched/release-schema.json
+++ b/schema/patched/release-schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "ocid": {
       "title": "Open Contracting ID",
-      "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/identifiers/)",
+      "description": "A globally unique identifier for this Open Contracting Process. Composed of a publisher prefix and an identifier for the contracting process. For more information see the [Open Contracting Identifier guidance](http://standard.open-contracting.org/1.1/{{lang}}/schema/identifiers/)",
       "type": "string",
       "minLength": 1
     },
@@ -27,7 +27,7 @@
     },
     "tag": {
       "title": "Release Tag",
-      "description": "One or more values from the [releaseTag codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#release-tag). Tags may be used to filter release and to understand the kind of information that a release might contain.",
+      "description": "One or more values from the [releaseTag codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#release-tag). Tags may be used to filter release and to understand the kind of information that a release might contain.",
       "type": "array",
       "items": {
         "type": "string",
@@ -340,7 +340,7 @@
         },
         "status": {
           "title": "Tender status",
-          "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#tender-status)",
+          "description": "The current status of the tender based on the [tenderStatus codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#tender-status)",
           "type": [
             "string",
             "null"
@@ -384,7 +384,7 @@
         },
         "procurementMethod": {
           "title": "Procurement method",
-          "description": "Specify tendering method using the [method codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#method). This is a closed codelist. Local method types should be mapped to this list.",
+          "description": "Specify tendering method using the [method codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#method). This is a closed codelist. Local method types should be mapped to this list.",
           "type": [
             "string",
             "null"
@@ -417,7 +417,7 @@
         },
         "mainProcurementCategory": {
           "title": "Main procurement category",
-          "description": "The primary category describing the main object of this contracting process from the [procurementCategory](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#procurement-category) codelist. This is a closed codelist. Local classifications should be mapped to this list.",
+          "description": "The primary category describing the main object of this contracting process from the [procurementCategory](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#procurement-category) codelist. This is a closed codelist. Local classifications should be mapped to this list.",
           "type": [
             "string",
             "null"
@@ -433,7 +433,7 @@
         },
         "additionalProcurementCategories": {
           "title": "Additional procurement categories",
-          "description": "Any additional categories which describe the objects of this contracting process, from the [extendedProcurementCategory](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#extended-procurement-category) codelist. This is an open codelist. Local categories can be included in this list.",
+          "description": "Any additional categories which describe the objects of this contracting process, from the [extendedProcurementCategory](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#extended-procurement-category) codelist. This is an open codelist. Local categories can be included in this list.",
           "type": [
             "array",
             "null"
@@ -448,7 +448,7 @@
         },
         "awardCriteria": {
           "title": "Award criteria",
-          "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#award-criteria)",
+          "description": "Specify the award criteria for the procurement, using the [award criteria codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#award-criteria)",
           "type": [
             "string",
             "null"
@@ -466,7 +466,7 @@
         },
         "submissionMethod": {
           "title": "Submission method",
-          "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#submission-method)",
+          "description": "Specify the method by which bids must be submitted, in person, written, or electronic auction. Using the [submission method codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#submission-method)",
           "type": [
             "array",
             "null"
@@ -540,7 +540,7 @@
         },
         "documents": {
           "title": "Documents",
-          "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#document-type) for details of potential documents to include. Common documents include official legal notices of tender, technical specifications, evaluation criteria, and, as a tender process progresses, clarifications and replies to queries.",
+          "description": "All documents and attachments related to the tender, including any notices. See the [documentType codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#document-type) for details of potential documents to include. Common documents include official legal notices of tender, technical specifications, evaluation criteria, and, as a tender process progresses, clarifications and replies to queries.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Document"
@@ -628,7 +628,7 @@
       "properties": {
         "id": {
           "title": "Award ID",
-          "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/identifiers/) for further details.",
+          "description": "The identifier for this award. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/1.1/{{lang}}/schema/identifiers/) for further details.",
           "type": [
             "string",
             "integer"
@@ -653,7 +653,7 @@
         },
         "status": {
           "title": "Award status",
-          "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#award-status)",
+          "description": "The current status of the award drawn from the [awardStatus codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#award-status)",
           "type": [
             "string",
             "null"
@@ -779,7 +779,7 @@
       "properties": {
         "id": {
           "title": "Contract ID",
-          "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/identifiers/) for further details.",
+          "description": "The identifier for this contract. It must be unique and cannot change within its Open Contracting Process (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/1.1/{{lang}}/schema/identifiers/) for further details.",
           "type": [
             "string",
             "integer"
@@ -813,7 +813,7 @@
         },
         "status": {
           "title": "Contract status",
-          "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#contract-status)",
+          "description": "The current status of the contract. Drawn from the [contractStatus codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#contract-status)",
           "type": [
             "string",
             "null"
@@ -1062,7 +1062,7 @@
         },
         "type": {
           "title": "Milestone type",
-          "description": "The type of milestone, drawn from an extended [milestoneType codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#milestone-type).",
+          "description": "The type of milestone, drawn from an extended [milestoneType codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#milestone-type).",
           "type": [
             "string",
             "null"
@@ -1117,7 +1117,7 @@
         },
         "status": {
           "title": "Status",
-          "description": "The status that was realized on the date provided in dateModified, drawn from the [milestoneStatus codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#milestone-status).",
+          "description": "The status that was realized on the date provided in dateModified, drawn from the [milestoneStatus codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#milestone-status).",
           "type": [
             "string",
             "null"
@@ -1176,7 +1176,7 @@
         },
         "documentType": {
           "title": "Document type",
-          "description": "A classification of the document described taken from the [documentType codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code.",
+          "description": "A classification of the document described taken from the [documentType codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#document-type). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code.",
           "type": [
             "string",
             "null"
@@ -1473,12 +1473,12 @@
         },
         "identifier": {
           "title": "Primary identifier",
-          "description": "The primary identifier for this organization or participant. Identifiers that uniquely pick out a legal entity should be preferred. Consult the [organization identifier guidance](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/identifiers/) for the preferred scheme and identifier to use.",
+          "description": "The primary identifier for this organization or participant. Identifiers that uniquely pick out a legal entity should be preferred. Consult the [organization identifier guidance](http://standard.open-contracting.org/1.1/{{lang}}/schema/identifiers/) for the preferred scheme and identifier to use.",
           "$ref": "#/definitions/Identifier"
         },
         "additionalIdentifiers": {
           "title": "Additional identifiers",
-          "description": "A list of additional / supplemental identifiers for the organization or participant, using the [organization identifier guidance](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
+          "description": "A list of additional / supplemental identifiers for the organization or participant, using the [organization identifier guidance](http://standard.open-contracting.org/1.1/{{lang}}/schema/identifiers/). This could be used to provide an internally used identifier for this organization in addition to the primary legal entity identifier.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Identifier"
@@ -1498,7 +1498,7 @@
         },
         "roles": {
           "title": "Party roles",
-          "description": "The party's role(s) in the contracting process. Role(s) should be taken from the [partyRole codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#party-role). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code.",
+          "description": "The party's role(s) in the contracting process. Role(s) should be taken from the [partyRole codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#party-role). Values from the provided codelist should be used wherever possible, though extended values can be provided if the codelist does not have a relevant code.",
           "type": [
             "array",
             "null"
@@ -1581,12 +1581,12 @@
         },
         "classification": {
           "title": "Classification",
-          "description": "The primary classification for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#item-classification-scheme) to identify preferred classification lists, including CPV and GSIN.",
+          "description": "The primary classification for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#item-classification-scheme) to identify preferred classification lists, including CPV and GSIN.",
           "$ref": "#/definitions/Classification"
         },
         "additionalClassifications": {
           "title": "Additional classifications",
-          "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme.",
+          "description": "An array of additional classifications for the item. See the [itemClassificationScheme](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#item-classification-scheme) codelist for common options to use in OCDS. This may also be used to present codes from an internal classification scheme.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Classification"
@@ -1612,7 +1612,7 @@
           "properties": {
             "scheme": {
               "title": "Scheme",
-              "description": "The list from which units of measure identifiers are taken. This should be an entry from the options available in the [unitClassificationScheme](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#unit-classification-scheme) codelist. Use of the scheme 'UNCEFACT' for the UN/CEFACT Recommendation 20 list of 'Codes for Units of Measure Used in International Trade' is recommended, although other options are available.",
+              "description": "The list from which units of measure identifiers are taken. This should be an entry from the options available in the [unitClassificationScheme](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#unit-classification-scheme) codelist. Use of the scheme 'UNCEFACT' for the UN/CEFACT Recommendation 20 list of 'Codes for Units of Measure Used in International Trade' is recommended, although other options are available.",
               "type": [
                 "string",
                 "null"
@@ -1752,7 +1752,7 @@
       "properties": {
         "scheme": {
           "title": "Scheme",
-          "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#item-classification-scheme) wherever possible.",
+          "description": "An classification should be drawn from an existing scheme or list of codes. This field is used to indicate the scheme/codelist from which the classification is drawn. For line item classifications, this value should represent an known [Item Classification Scheme](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#item-classification-scheme) wherever possible.",
           "type": [
             "string",
             "null"
@@ -1803,7 +1803,7 @@
       "properties": {
         "scheme": {
           "title": "Scheme",
-          "description": "Organization identifiers should be drawn from an existing organization identifier list. The scheme field is used to indicate the list or register from which the identifier is drawn. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#organization-identifier-scheme) codelist.",
+          "description": "Organization identifiers should be drawn from an existing organization identifier list. The scheme field is used to indicate the list or register from which the identifier is drawn. This value should be drawn from the [Organization Identifier Scheme](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#organization-identifier-scheme) codelist.",
           "type": [
             "string",
             "null"
@@ -2286,7 +2286,7 @@
     },
     "Period": {
       "title": "Period",
-      "description": "Key events during a contracting process may have a known state date, end date, duration, or maximum extent (the latest date the period can extend to). In some cases, not all of these fields will have known or relevant values.",
+      "description": "Key events during a contracting process may have a known start date, end date, duration, or maximum extent (the latest date the period can extend to). In some cases, not all of these fields will have known or relevant values.",
       "type": "object",
       "properties": {
         "startDate": {
@@ -2342,7 +2342,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Specify the type of relationship using the [related process codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#related-process).",
+          "description": "Specify the type of relationship using the [related process codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#related-process).",
           "title": "Relationship",
           "type": [
             "array",
@@ -2361,7 +2361,7 @@
         },
         "scheme": {
           "title": "Scheme",
-          "description": "The identification scheme used by this cross-reference from the [related process scheme codelist](http://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#related-process-scheme) codelist. When cross-referencing information also published using OCDS, an Open Contracting ID (ocid) should be used.",
+          "description": "The identification scheme used by this cross-reference from the [related process scheme codelist](http://standard.open-contracting.org/1.1/{{lang}}/schema/codelists/#related-process-scheme) codelist. When cross-referencing information also published using OCDS, an Open Contracting ID (ocid) should be used.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
closes #173

Depends on: https://github.com/open-contracting/documentation-support/pull/26