### PR TITLE
[#170] Change locations of directories

### DIFF
--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -3,7 +3,7 @@
 
 # The following lines are updated based on the `repos:dependencies` task in standard-maintenance-scripts.
 
--e git+https://github.com/open-contracting/documentation-support.git@b4f87383702a97d130b71e183497be9090083451#egg=ocdsdocumentationsupport
+-e git+https://github.com/open-contracting/documentation-support.git@14f21b2131c947de35be6637f6a71fe1eb375327#egg=ocdsdocumentationsupport
 -e git+https://github.com/open-contracting/sphinxcontrib-opencontracting.git@665ef3b2e0b03d196233ba26524bdb2ca5abe09e#egg=sphinxcontrib-opencontracting
 -e git+https://github.com/OpenDataServices/sphinxcontrib-jsonschema.git@7b696eef47cc14c46a20c67abff18dc794e2f6cc#egg=sphinxcontrib-jsonschema
 -e git+https://github.com/OpenDataServices/sphinxcontrib-opendataservices.git@fab0ff0167d32ec243d42f272e0e50766299c078#egg=sphinxcontrib-opendataservices

--- a/docs/_static/ocds-show/example/full.json
+++ b/docs/_static/ocds-show/example/full.json
@@ -2,7 +2,7 @@
     "version": "1.1",
     "license": "http://opendatacommons.org/licenses/pddl/1.0/",
     "extensions": [
-      "http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/extension.json"
+      "http://standard.open-contracting.org/profiles/ppp/extension/1__0__0__beta/extension.json"
     ],
     "publishedDate": "2020-01-24T00:00:00Z",
     "publisher": {

--- a/docs/_static/ocds-show/example/full_record_package.json
+++ b/docs/_static/ocds-show/example/full_record_package.json
@@ -2,7 +2,7 @@
   "version": "1.1",
   "license": "http://opendatacommons.org/licenses/pddl/1.0/",
   "extensions": [
-    "http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/extension.json"
+    "http://standard.open-contracting.org/profiles/ppp/extension/1__0__0__beta/extension.json"
   ],
   "publishedDate": "2020-01-24T00:00:00Z",
   "publisher": {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,6 +126,10 @@ gettext_domain_prefix = 'ppp-'
 standard_tag = '1__1__3'
 standard_version = '1.1'
 
+# Where the patched schemas will be deployed.
+schema_base_url = 'http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/'
+
+
 # List the extension identifiers and versions that should be part of this profile. The extensions must be available in
 # the extension registry: https://github.com/open-contracting/extension_registry/blob/master/extension_versions.csv
 extension_versions = OrderedDict([
@@ -170,6 +174,7 @@ def setup(app):
 
     arguments = (
         (['patched/release-schema.json'], 'schema', os.path.join('docs', '_static')),
+        (['patched/release-package-schema.json'], 'schema', os.path.join('docs', '_static')),
         (['release-schema.json'], 'schema/profile', os.path.join('build', language)),
     )
 

--- a/docs/examples/full.json
+++ b/docs/examples/full.json
@@ -2,7 +2,7 @@
   "version": "1.1",
   "license": "http://opendatacommons.org/licenses/pddl/1.0/",
   "extensions": [
-    "http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/extension.json"
+    "http://standard.open-contracting.org/profiles/ppp/extension/1__0__0__beta/extension.json"
   ],
   "publishedDate": "2020-01-24T00:00:00Z",
   "publisher": {

--- a/docs/examples/full_record_package.json
+++ b/docs/examples/full_record_package.json
@@ -2,7 +2,7 @@
   "version": "1.1",
   "license": "http://opendatacommons.org/licenses/pddl/1.0/",
   "extensions": [
-    "http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/extension.json"
+    "http://standard.open-contracting.org/profiles/ppp/extension/1__0__0__beta/extension.json"
   ],
   "publishedDate": "2020-01-24T00:00:00Z",
   "publisher": {

--- a/docs/extensions/ppp.md
+++ b/docs/extensions/ppp.md
@@ -10,7 +10,7 @@ The consolidated OCDS for PPPs extension can be declared in [OCDS package metada
 
 ```json
 {
-    "extensions":["http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/extension.json"],
+    "extensions":["http://standard.open-contracting.org/profiles/ppp/extension/1__0__0__beta/extension.json"],
     "releases":[]
 }
 ```

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -19,7 +19,7 @@ To produce and validate OCDS for PPPs data, create an [OCDS 1.1 file](http://sta
 
 ```json
 {
-  "extensions":["http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/extension.json"],
+  "extensions":["http://standard.open-contracting.org/profiles/ppp/extension/1__0__0__beta/extension.json"],
   "releases":[]
 }
 ```

--- a/schema/build-profile.py
+++ b/schema/build-profile.py
@@ -9,6 +9,6 @@ from ocdsdocumentationsupport import build_profile
 basedir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(basedir, '..', 'docs'))
 
-from conf import standard_tag, standard_version, extension_versions  # noqa
+from conf import standard_tag, standard_version, extension_versions, schema_base_url  # noqa
 
-build_profile(basedir, standard_tag, extension_versions)
+build_profile(basedir, standard_tag, extension_versions, schema_base_url=schema_base_url)

--- a/schema/patched/release-package-schema.json
+++ b/schema/patched/release-package-schema.json
@@ -1,0 +1,110 @@
+{
+  "id": "http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/release-package-schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Schema for an Open Contracting Release Package",
+  "description": "Note that all releases within a release package must have a unique releaseID within this release package.",
+  "type": "object",
+  "required": [
+    "uri",
+    "publisher",
+    "publishedDate",
+    "releases",
+    "version"
+  ],
+  "properties": {
+    "uri": {
+      "title": "Package identifier",
+      "description": "The URI of this package that identifies it uniquely in the world. Recommended practice is to use a dereferenceable URI, where a persistent copy of this package is available.",
+      "type": "string",
+      "format": "uri"
+    },
+    "version": {
+      "title": "OCDS schema version",
+      "description": "The version of the OCDS schema used in this package, expressed as major.minor For example: 1.0 or 1.1",
+      "type": "string",
+      "pattern": "^(\\d+\\.)(\\d+)$"
+    },
+    "extensions": {
+      "title": "OCDS extensions",
+      "description": "An array of OCDS extensions used in this package. Each entry should be a URL to the extension.json file for that extension.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "publishedDate": {
+      "title": "Published date",
+      "description": "The date that this package was published. If this package is generated 'on demand', this date should reflect the date of the last change to the underlying contents of the package.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "releases": {
+      "title": "Releases",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/release-schema.json"
+      },
+      "uniqueItems": true
+    },
+    "publisher": {
+      "title": "Publisher",
+      "description": "Information to uniquely identify the publisher of this package.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "The name of the organization or department responsible for publishing this data.",
+          "type": "string"
+        },
+        "scheme": {
+          "title": "Scheme",
+          "description": "The scheme that holds the unique identifiers used to identify the item being identified.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid": {
+          "title": "uid",
+          "description": "The unique ID for this entity under the given ID scheme. Note the use of 'uid' rather than 'id'. See issue #245.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uri": {
+          "title": "URI",
+          "description": "A URI to identify the publisher.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "license": {
+      "title": "License",
+      "description": "A link to the license that applies to the data in this package. A Public Domain Dedication or [Open Definition Conformant](http://opendefinition.org/licenses/) license is strongly recommended. The canonical URI of the license should be used. Documents linked from this file may be under other license conditions. ",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri"
+    },
+    "publicationPolicy": {
+      "title": "Publication policy",
+      "description": "A link to a document describing the publishers [publication policy](http://standard.open-contracting.org/{{version}}/{{lang}}/implementation/publication_policy/).",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri"
+    }
+  }
+}

--- a/schema/patched/release-schema.json
+++ b/schema/patched/release-schema.json
@@ -1,5 +1,5 @@
 {
-  "id": "http://standard.open-contracting.org/schema/1__1__3/release-schema.json",
+  "id": "http://standard.open-contracting.org/profiles/ppp/schema/1__0__0__beta/release-schema.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Schema for an Open Contracting Release",
   "description": "Each release provides data about a single contracting process at a particular point in time. Releases can be used to notify users of new tenders, awards, contracts and other updates. Releases may repeat or update information provided previously in this contracting process. One contracting process may have many releases. A 'record' of a contracting process follows the same structure as a release, but combines information from multiple points in time into a single summary.",


### PR DESCRIPTION
Changes needed for the deploy of 1.0.0.beta:

- Specifies a schema directory for the patched schemas so that they appear in the `id` field.
- Adds release-package-schema.json to the patched schema directory.
- Changes the directories to `/schema` for the patched schamas and `/extension` for the full profile patch
- Update the docs and examples to match.