### PR TITLE
Update codelist reference

### DIFF
--- a/docs/reference/codelists.md
+++ b/docs/reference/codelists.md
@@ -20,7 +20,7 @@ For more information on open and closed codelists, refer to the Open Contracting
 
 ## OCDS codelists
 
-OCDS for PPPs reuses some codelists from the Open Contracting Data Standard, without modification. Refer to the core OCDS documentation for details of these codelists:
+OCDS for PPPs reuses some codelists from the Open Contracting Data Standard, without modification. Refer to the OCDS documentation for details of these codelists:
 
 ### Closed codelists
 
@@ -32,7 +32,7 @@ OCDS for PPPs reuses some codelists from the Open Contracting Data Standard, wit
 * [Procurement category](http://standard.open-contracting.org/latest/en/schema/codelists/#procurement-category)
 * [Tender status](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)
 
-### Open Codelists
+### Open codelists
 
 * [Award criteria](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)
 * [Extended procurement category](http://standard.open-contracting.org/latest/en/schema/codelists/#extended-procurement-category)
@@ -45,7 +45,7 @@ OCDS for PPPs reuses some codelists from the Open Contracting Data Standard, wit
 
 ## OCDS for PPPs codelists
 
-OCDS for PPPs also modifies some codelists from OCDS core and uses codelists from individual extensions, including the OCDS for PPPs extension. The 'extension' column in the table display below indicates where each code originates from.
+OCDS for PPPs modifies some codelists from OCDS and reuses codelists from extensions, without modification. The 'Extension' column in the tables below indicates where each code originates from.
 
 ### Closed codelists
 

--- a/docs/reference/codelists.md
+++ b/docs/reference/codelists.md
@@ -1,8 +1,22 @@
 # Codelists
 
-OCDS for PPPs uses two types of codelist, **open** and **closed**. An **open** codelist provides **suggested** codes which can be added to by publishers, whilst a **closed** codelist provides **mandatory** codes and publishers should only use values provided in the official list. Codes are case sensitive, and are generally provided as English language camelCase.
+Some schema fields refer to codelists, to limit and standardize the possible values of the fields, in order to promote data interoperability.
 
-You can read more about using codelists in the [core OCDS documentation](http://standard.open-contracting.org/latest/en/) and further details on codelists in extensions can be found in the [extension reference](../extensions/index.md).
+Codelists can either be open or closed. **Closed codelists** are intended to be comprehensive; for example, the [currency](http://standard.open-contracting.org/latest/en/schema/codelists/#currency) codelist covers all currencies in the world. **Open codelists** are intended to be representative, but not comprehensive.
+
+Publishers must use the codes in the codelists, unless no code is appropriate. If no code is appropriate and the codelist is **open**, then a publisher may use a new code outside those in the codelist. If no code is appropriate and the codelist is **closed**, then a publisher should instead create an issue in the [OCDS for PPPs GitHub repository](https://github.com/open-contracting-extensions/public-private-partnerships/issues).
+
+```eval_rst
+.. admonition:: Extending open codelists
+    :class: Tip
+
+    .. markdown::
+
+      If you use new codes outside those in an open codelist, please create an issue in the [OCDS for PPPs GitHub repository](https://github.com/open-contracting-extensions/public-private-partnerships/issues), so that the codes can be considered for inclusion in the codelist.
+
+```
+
+For more information on open and closed codelists, refer to the Open Contracting Data Standard [codelists documentation](http://standard.open-contracting.org/latest/en/schema/codelists/).
 
 ## OCDS codelists
 

--- a/docs/reference/codelists.md
+++ b/docs/reference/codelists.md
@@ -23,8 +23,11 @@ OCDS for PPPs reuses some codelists from the Open Contracting Data Standard, wit
 * [Award criteria](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)
 * [Extended procurement category](http://standard.open-contracting.org/latest/en/schema/codelists/#extended-procurement-category)
 * [Item classification scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme)
+* [Organization identifier scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)
+* [Related process](http://standard.open-contracting.org/latest/en/schema/codelists/#related-process)
 * [Related process scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#related-process)
 * [Submission method](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)
+* [Unit classification scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#unit-classification-scheme)
 
 ## OCDS for PPPs codelists
 

--- a/docs/reference/codelists.md
+++ b/docs/reference/codelists.md
@@ -1,22 +1,38 @@
 # Codelists
 
-OCDS for PPPs uses a combination of codes and codelists from OCDS core, individual extensions and the PPP extension itself. The 'extension' column in the table display below indicates where each code originates from.
-
 OCDS for PPPs uses two types of codelist, **open** and **closed**. An **open** codelist provides **suggested** codes which can be added to by publishers, whilst a **closed** codelist provides **mandatory** codes and publishers should only use values provided in the official list. Codes are case sensitive, and are generally provided as English language camelCase.
 
 You can read more about using codelists in the [core OCDS documentation](http://standard.open-contracting.org/latest/en/) and further details on codelists in extensions can be found in the [extension reference](../extensions/index.md).
 
-## Closed codelists
+## OCDS codelists
 
-### awardStatus
+OCDS for PPPs reuses some codelists from the Open Contracting Data Standard, without modification. Refer to the core OCDS documentation for details of these codelists:
 
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/awardStatus.csv
-```
+### Closed codelists
 
-### bidStatus
+* [Award status](http://standard.open-contracting.org/latest/en/schema/codelists/#award-status)
+* [Contract status](http://standard.open-contracting.org/latest/en/schema/codelists/#contract-status)
+* [Currency](http://standard.open-contracting.org/latest/en/schema/codelists/#currency)
+* [Procurement method](http://standard.open-contracting.org/latest/en/schema/codelists/#method)
+* [Milestone status](http://standard.open-contracting.org/latest/en/schema/codelists/#milestone-status)
+* [Procurement category](http://standard.open-contracting.org/latest/en/schema/codelists/#procurement-category)
+* [Tender status](http://standard.open-contracting.org/latest/en/schema/codelists/#tender-status)
+
+### Open Codelists
+
+* [Award criteria](http://standard.open-contracting.org/latest/en/schema/codelists/#award-criteria)
+* [Extended procurement category](http://standard.open-contracting.org/latest/en/schema/codelists/#extended-procurement-category)
+* [Item classification scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme)
+* [Related process scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#related-process)
+* [Submission method](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)
+
+## OCDS for PPPs codelists
+
+OCDS for PPPs also modifies some codelists from OCDS core and uses codelists from individual extensions and the PPP extension itself. The 'extension' column in the table display below indicates where each code originates from.
+
+### Closed codelists
+
+#### bidStatus
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -24,23 +40,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/bidStatus.csv
 ```
 
-### contractStatus
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/contractStatus.csv
-```
-
-### currency
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/currency.csv
-```
-
-### dataType
+#### dataType
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -48,7 +48,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/dataType.csv
 ```
 
-### financeCategory
+#### financeCategory
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -56,7 +56,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/financeCategory.csv
 ```
 
-### initiationType
+#### initiationType
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -64,23 +64,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/initiationType.csv
 ```
 
-### method
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/method.csv
-```
-
-### milestoneStatus
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/milestoneStatus.csv
-```
-
-### preQualificationStatus
+#### preQualificationStatus
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -88,15 +72,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/preQualificationStatus.csv
 ```
 
-### procurementCategory
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/procurementCategory.csv
-```
-
-### relatesTo
+#### relatesTo
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -104,7 +80,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/relatesTo.csv
 ```
 
-### releaseTag
+#### releaseTag
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -112,7 +88,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/releaseTag.csv
 ```
 
-### responseSource
+#### responseSource
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -120,7 +96,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/responseSource.csv
 ```
 
-### riskAllocation
+#### riskAllocation
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -128,15 +104,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/riskAllocation.csv
 ```
 
-### tenderStatus
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/tenderStatus.csv
-```
-
-### votingRights
+#### votingRights
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -144,17 +112,9 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/votingRights.csv
 ```
 
-## Open codelists
+### Open codelists
 
-### awardCriteria
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/awardCriteria.csv
-```
-
-### bidStatistics
+#### bidStatistics
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -162,7 +122,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/bidStatistics.csv
 ```
 
-### documentType
+#### documentType
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -170,23 +130,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/documentType.csv
 ```
 
-### extendedProcurementCategory
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/extendedProcurementCategory.csv
-```
-
-### itemClassificationScheme
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/itemClassificationScheme.csv
-```
-
-### milestoneCode
+#### milestoneCode
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -194,7 +138,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/milestoneCode.csv
 ```
 
-### milestoneType
+#### milestoneType
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -202,7 +146,7 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/milestoneType.csv
 ```
 
-### partyRole
+#### partyRole
 
 ```eval_rst
 .. csv-table-no-translate::
@@ -210,26 +154,10 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/partyRole.csv
 ```
 
-### relatedProcessScheme
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/relatedProcessScheme.csv
-```
-
-### riskCategory
+#### riskCategory
 
 ```eval_rst
 .. csv-table-no-translate::
    :header-rows: 1
    :file: ../_static/patched/codelists/riskCategory.csv
-```
-
-### submissionMethod
-
-```eval_rst
-.. csv-table-no-translate::
-   :header-rows: 1
-   :file: ../_static/patched/codelists/submissionMethod.csv
 ```

--- a/docs/reference/codelists.md
+++ b/docs/reference/codelists.md
@@ -186,6 +186,22 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :file: ../_static/patched/codelists/itemClassificationScheme.csv
 ```
 
+### milestoneCode
+
+```eval_rst
+.. csv-table-no-translate::
+   :header-rows: 1
+   :file: ../_static/patched/codelists/milestoneCode.csv
+```
+
+### milestoneType
+
+```eval_rst
+.. csv-table-no-translate::
+   :header-rows: 1
+   :file: ../_static/patched/codelists/milestoneType.csv
+```
+
 ### partyRole
 
 ```eval_rst
@@ -217,4 +233,3 @@ You can read more about using codelists in the [core OCDS documentation](http://
    :header-rows: 1
    :file: ../_static/patched/codelists/submissionMethod.csv
 ```
-

--- a/docs/reference/codelists.md
+++ b/docs/reference/codelists.md
@@ -39,13 +39,13 @@ OCDS for PPPs reuses some codelists from the Open Contracting Data Standard, wit
 * [Item classification scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#item-classification-scheme)
 * [Organization identifier scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#organization-identifier-scheme)
 * [Related process](http://standard.open-contracting.org/latest/en/schema/codelists/#related-process)
-* [Related process scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#related-process)
+* [Related process scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#related-process-scheme)
 * [Submission method](http://standard.open-contracting.org/latest/en/schema/codelists/#submission-method)
 * [Unit classification scheme](http://standard.open-contracting.org/latest/en/schema/codelists/#unit-classification-scheme)
 
 ## OCDS for PPPs codelists
 
-OCDS for PPPs also modifies some codelists from OCDS core and uses codelists from individual extensions and the PPP extension itself. The 'extension' column in the table display below indicates where each code originates from.
+OCDS for PPPs also modifies some codelists from OCDS core and uses codelists from individual extensions, including the OCDS for PPPs extension. The 'extension' column in the table display below indicates where each code originates from.
 
 ### Closed codelists
 

--- a/docs/reference/codelists.md
+++ b/docs/reference/codelists.md
@@ -57,6 +57,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :file: ../_static/patched/codelists/bidStatus.csv
 ```
 
+For additional guidance on using this codelist, refer to the [Bid statistics and details extension documentation](https://extensions.open-contracting.org/en/extensions/bids/v1.1.4/).
+
 #### dataType
 
 ```eval_rst
@@ -64,6 +66,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :header-rows: 1
    :file: ../_static/patched/codelists/dataType.csv
 ```
+
+For additional guidance on using this codelist, refer to the [Requirements extension documentation](https://extensions.open-contracting.org/en/extensions/requirements/master/).
 
 #### financeCategory
 
@@ -73,6 +77,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :file: ../_static/patched/codelists/financeCategory.csv
 ```
 
+For additional guidance on using this codelist, refer to the [Financing extension documentation](https://extensions.open-contracting.org/en/extensions/finance/master/).
+
 #### initiationType
 
 ```eval_rst
@@ -80,6 +86,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :header-rows: 1
    :file: ../_static/patched/codelists/initiationType.csv
 ```
+
+For additional guidance on using this codelist, refer to the [OCDS for PPPs extension documentation](https://extensions.open-contracting.org/en/extensions/ppp/master/).
 
 #### preQualificationStatus
 
@@ -89,6 +97,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :file: ../_static/patched/codelists/preQualificationStatus.csv
 ```
 
+For additional guidance on using this codelist, refer to the [Qualification extension documentation](https://extensions.open-contracting.org/en/extensions/qualification/master/).
+
 #### relatesTo
 
 ```eval_rst
@@ -96,6 +106,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :header-rows: 1
    :file: ../_static/patched/codelists/relatesTo.csv
 ```
+
+For additional guidance on using this codelist, refer to the [Requirements extension documentation](https://extensions.open-contracting.org/en/extensions/requirements/master/).
 
 #### releaseTag
 
@@ -105,6 +117,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :file: ../_static/patched/codelists/releaseTag.csv
 ```
 
+For additional guidance on using this codelist, refer to the [OCDS for PPPs extension documentation](https://extensions.open-contracting.org/en/extensions/ppp/master/).
+
 #### responseSource
 
 ```eval_rst
@@ -112,6 +126,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :header-rows: 1
    :file: ../_static/patched/codelists/responseSource.csv
 ```
+
+For additional guidance on using this codelist, refer to the [Requirements extension documentation](https://extensions.open-contracting.org/en/extensions/requirements/master/).
 
 #### riskAllocation
 
@@ -121,6 +137,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :file: ../_static/patched/codelists/riskAllocation.csv
 ```
 
+For additional guidance on using this codelist, refer to the [Risk allocation extension documentation](https://extensions.open-contracting.org/en/extensions/risk_allocation/master/).
+
 #### votingRights
 
 ```eval_rst
@@ -128,6 +146,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :header-rows: 1
    :file: ../_static/patched/codelists/votingRights.csv
 ```
+
+For additional guidance on using this codelist, refer to the [Shareholders extension documentation](https://extensions.open-contracting.org/en/extensions/shareholders/master/).
 
 ### Open codelists
 
@@ -139,6 +159,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :file: ../_static/patched/codelists/bidStatistics.csv
 ```
 
+For additional guidance on using this codelist, refer to the [Bid statistics and details extension documentation](https://extensions.open-contracting.org/en/extensions/bids/v1.1.4/).
+
 #### documentType
 
 ```eval_rst
@@ -146,6 +168,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :header-rows: 1
    :file: ../_static/patched/codelists/documentType.csv
 ```
+
+For additional guidance on using this codelist, refer to the [OCDS for PPPs extension documentation](https://extensions.open-contracting.org/en/extensions/ppp/master/).
 
 #### milestoneCode
 
@@ -155,6 +179,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :file: ../_static/patched/codelists/milestoneCode.csv
 ```
 
+For additional guidance on using this codelist, refer to the [OCDS for PPPs extension documentation](https://extensions.open-contracting.org/en/extensions/ppp/master/).
+
 #### milestoneType
 
 ```eval_rst
@@ -162,6 +188,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :header-rows: 1
    :file: ../_static/patched/codelists/milestoneType.csv
 ```
+
+For additional guidance on using this codelist, refer to the [OCDS milestone type codelist documentation](http://standard.open-contracting.org/latest/en/schema/codelists/#milestone-type).
 
 #### partyRole
 
@@ -171,6 +199,8 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :file: ../_static/patched/codelists/partyRole.csv
 ```
 
+For additional guidance on using this codelist, refer to the [OCDS party role codelist documentation](http://standard.open-contracting.org/latest/en/schema/codelists/#party-role).
+
 #### riskCategory
 
 ```eval_rst
@@ -178,3 +208,5 @@ OCDS for PPPs also modifies some codelists from OCDS core and uses codelists fro
    :header-rows: 1
    :file: ../_static/patched/codelists/riskCategory.csv
 ```
+
+For additional guidance on using this codelist, refer to the [Risk allocation extension documentation](https://extensions.open-contracting.org/en/extensions/risk_allocation/master/).


### PR DESCRIPTION
Closes #186 

In addition to the points in #186 I've also added some codelists that were missing altogether (related process, item classification scheme and organization identifier scheme) and updated the guidance on open/closed codelists to match that from OC4IDS, which is clearer.

@jpmckinney do you want to add the changes to `build_profile.py` to this PR?



