### PR TITLE
Change documentation URLs in schema for modified codelists

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "docs/_static/docson"]
 	path = docs/_static/docson
 	url = https://github.com/OpenDataServices/docson
+	branch = master

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import os
+import re
 from collections import OrderedDict
 from glob import glob
 from pathlib import Path
@@ -115,6 +116,16 @@ html_static_path = ['_static', 'examples']
 
 
 # -- Local configuration --------------------------------------------------
+
+def update_codelist_urls(text, codelists):
+    def replace(match):
+        codelist = match.group(2).replace('-', '')
+        if any(name for name in codelists if name.lower()[:-4] == codelist):
+            return match.group(1) + 'profiles/ppp/latest/{{lang}}/reference/codelists/#' + codelist
+        return match.group()
+
+    return re.sub(r'(://standard\.open-contracting\.org/)[^/]+/[^/]+/schema/codelists/#([a-z-]+)', replace, text)
+
 
 profile_identifier = 'ppp'
 repository_url = 'https://github.com/open-contracting-extensions/public-private-partnerships'

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -10,7 +10,7 @@
   * The description of 'needsAssessment' has been updated to match the description from OC4IDS.
   * The description of 'environmentalImpact' has been updated to match the description from OC4IDS.
 
-## Non-normative changes
+### Non-normative changes
 
 * [#222](https://github.com/open-contracting-extensions/public-private-partnerships/pull/222) Clarify the one-to-one correspondence between a PPP project and a contracting process.
 * [#195](https://github.com/open-contracting-extensions/public-private-partnerships/pull/195) The documentation pages of all extensions have been moved to the new [Extension Explorer](https://extensions.open-contracting.org/).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,6 +9,10 @@ This section contains OCDS for PPP specific reference materials.
    :maxdepth: 1
    :glob:
 
-   *
+   browser
+   schema
+   codelists
+   documents
+   changelog
 
 ```

--- a/schema/build-profile.py
+++ b/schema/build-profile.py
@@ -9,6 +9,7 @@ from ocdsextensionregistry import build_profile
 basedir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(basedir, '..', 'docs'))
 
-from conf import standard_tag, standard_version, extension_versions, schema_base_url  # noqa
+from conf import standard_tag, standard_version, extension_versions, schema_base_url, update_codelist_urls  # noqa
 
-build_profile(basedir, standard_tag, extension_versions, schema_base_url=schema_base_url)
+build_profile(basedir, standard_tag, extension_versions, schema_base_url=schema_base_url,
+              update_codelist_urls=update_codelist_urls)

--- a/schema/patched/release-schema.json
+++ b/schema/patched/release-schema.json
@@ -27,7 +27,7 @@
     },
     "tag": {
       "title": "Release Tag",
-      "description": "One or more values from the closed [releaseTag](https://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#release-tag) codelist. Tags can be used to filter releases and to understand the kind of information that releases might contain.",
+      "description": "One or more values from the closed [releaseTag](https://standard.open-contracting.org/profiles/ppp/latest/{{lang}}/reference/codelists/#releasetag) codelist. Tags can be used to filter releases and to understand the kind of information that releases might contain.",
       "type": "array",
       "items": {
         "type": "string",
@@ -63,7 +63,7 @@
     },
     "initiationType": {
       "title": "Initiation type",
-      "description": "String specifying the type of initiation process used for this contract, taken from the initiationType codelist. In OCDS for PPPs, only ppp is supported.",
+      "description": "The type of initiation process used for this contract, from the closed [initiationType](https://standard.open-contracting.org/profiles/ppp/latest/{{lang}}/reference/codelists/#initiationtype) codelist.",
       "type": "string",
       "enum": [
         "ppp"
@@ -458,7 +458,7 @@
         },
         "documents": {
           "title": "Documents",
-          "description": "All documents and attachments related to the tender, including any notices. See the [documentType](https://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#document-type) codelist for details of potential documents to include. Common documents include official legal notices of tender, technical specifications, evaluation criteria, and, as a tender process progresses, clarifications and replies to queries.",
+          "description": "All documents and attachments related to the tender, including any notices. See the [documentType](https://standard.open-contracting.org/profiles/ppp/latest/{{lang}}/reference/codelists/#documenttype) codelist for details of potential documents to include. Common documents include official legal notices of tender, technical specifications, evaluation criteria, and, as a tender process progresses, clarifications and replies to queries.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Document"
@@ -990,7 +990,7 @@
         },
         "type": {
           "title": "Milestone type",
-          "description": "The nature of the milestone, using the open [milestoneType](https://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#milestone-type) codelist.",
+          "description": "The nature of the milestone, using the open [milestoneType](https://standard.open-contracting.org/profiles/ppp/latest/{{lang}}/reference/codelists/#milestonetype) codelist.",
           "type": [
             "string",
             "null"
@@ -1104,7 +1104,7 @@
         },
         "documentType": {
           "title": "Document type",
-          "description": "A classification of the document described, using the open [documentType](https://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#document-type) codelist.",
+          "description": "A classification of the document described, using the open [documentType](https://standard.open-contracting.org/profiles/ppp/latest/{{lang}}/reference/codelists/#documenttype) codelist.",
           "type": [
             "string",
             "null"
@@ -1421,7 +1421,7 @@
         },
         "roles": {
           "title": "Party roles",
-          "description": "The party's role(s) in the contracting process, using the open [partyRole](https://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#party-role) codelist.",
+          "description": "The party's role(s) in the contracting process, using the open [partyRole](https://standard.open-contracting.org/profiles/ppp/latest/{{lang}}/reference/codelists/#partyrole) codelist.",
           "type": [
             "array",
             "null"
@@ -3089,7 +3089,6 @@
         "period": {
           "title": "Performance failure period",
           "description": "The reporting period for these performance failures.",
-          "type": "object",
           "$ref": "#/definitions/Period"
         },
         "category": {
@@ -3260,7 +3259,7 @@
         },
         "documents": {
           "title": "Documents",
-          "description": "All documents and attachments related to the pre-qualification, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
+          "description": "All documents and attachments related to the pre-qualification, including any notices. See the [documentType codelist](http://standard.open-contracting.org/profiles/ppp/latest/{{lang}}/reference/codelists/#documenttype) for details of potential documents to include.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Document"
@@ -3698,7 +3697,7 @@
         },
         "votingRights": {
           "title": "Shareholder voting rights",
-          "description": "Specify the type of voting rights associated with the shares held by the shareholder against the [voting rights codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#voting-rights).",
+          "description": "Specify the type of voting rights associated with the shares held by the shareholder against the voting rights codelist.",
           "type": [
             "string",
             "null"

--- a/schema/profile/release-schema.json
+++ b/schema/profile/release-schema.json
@@ -55,7 +55,6 @@
       }
     },
     "initiationType": {
-      "description": "String specifying the type of initiation process used for this contract, taken from the initiationType codelist. In OCDS for PPPs, only ppp is supported.",
       "enum": [
         "ppp"
       ]
@@ -1118,7 +1117,6 @@
         "period": {
           "title": "Performance failure period",
           "description": "The reporting period for these performance failures.",
-          "type": "object",
           "$ref": "#/definitions/Period"
         },
         "category": {
@@ -1289,7 +1287,7 @@
         },
         "documents": {
           "title": "Documents",
-          "description": "All documents and attachments related to the pre-qualification, including any notices. See the [documentType codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#document-type) for details of potential documents to include.",
+          "description": "All documents and attachments related to the pre-qualification, including any notices. See the [documentType codelist](http://standard.open-contracting.org/profiles/ppp/latest/{{lang}}/reference/codelists/#documenttype) for details of potential documents to include.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Document"
@@ -1727,7 +1725,7 @@
         },
         "votingRights": {
           "title": "Shareholder voting rights",
-          "description": "Specify the type of voting rights associated with the shares held by the shareholder against the [voting rights codelist](http://standard.open-contracting.org/latest/en/schema/codelists/#voting-rights).",
+          "description": "Specify the type of voting rights associated with the shares held by the shareholder against the voting rights codelist.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
Try initiationType, releaseTag, documentType, milestoneType and/or partyRole at https://standard.open-contracting.org/profiles/ppp/codelisturls/en/reference/browser/

This mixes in updates to the ppp, shareholders, and performance failures extensions.