### PR TITLE
fix link to example data

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -31,7 +31,7 @@ View the [OCDS releases in JSON format here](../_static/full.json).
 
 View the [OCDS record in JSON format here](../_static/full_record_package.json).
 
-View the [data in OCDS show here](https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting/ocds-show-ppp/gh-pages/example/full_record_package.json).
+View the [data in OCDS show here](https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting/ocds-show-ppp/master/example/full_record_package.json).
 
 In the record within OCDS show:
 


### PR DESCRIPTION
Fix for OCDS show not loading the example file when clicking the 'View the data in OCDS show here' link on the [worked example page](https://standard.open-contracting.org/profiles/ppp/latest/en/example/) in 1.0.0-beta2.

