### PR TITLE
update spreadsheet template and worked example links

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -9,7 +9,7 @@ This allows different stakeholders to understand how a project has developed.
 ## Details
 
 ```{image} _static/images/ocds_show.png
-:target: https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting/ocds-show-ppp/master/example/full.json
+:target: https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting-extensions/public-private-partnerships/1.0-dev/docs/examples/
 ```
 
 Based on our pilot work with the Red Compartida programme, we have created a fictional example PPP.
@@ -30,7 +30,7 @@ View the {download}`OCDS releases in JSON format here <examples/full.json>`.
 
 View the {download}`OCDS record in JSON format here <examples/full_record_package.json>`.
 
-View the [data in OCDS show here](https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting/ocds-show-ppp/master/example/full_record_package.json).
+View the [data in OCDS show here](https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting-extensions/public-private-partnerships/1.0-dev/docs/examples/).
 
 In the record within OCDS show:
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -9,7 +9,7 @@ This allows different stakeholders to understand how a project has developed.
 ## Details
 
 ```{image} _static/images/ocds_show.png
-:target: https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting-extensions/public-private-partnerships/1.0-dev/docs/examples/
+:target: https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting-extensions/public-private-partnerships/1.0-dev/docs/examples/full_record_package.json
 ```
 
 Based on our pilot work with the Red Compartida programme, we have created a fictional example PPP.
@@ -30,7 +30,7 @@ View the {download}`OCDS releases in JSON format here <examples/full.json>`.
 
 View the {download}`OCDS record in JSON format here <examples/full_record_package.json>`.
 
-View the [data in OCDS show here](https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting-extensions/public-private-partnerships/1.0-dev/docs/examples/).
+View the [data in OCDS show here](https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting-extensions/public-private-partnerships/1.0-dev/docs/examples/full_record_package.json).
 
 In the record within OCDS show:
 

--- a/docs/spreadsheet.md
+++ b/docs/spreadsheet.md
@@ -1,19 +1,19 @@
 # Spreadsheet template
 
-In most cases, OCDS for PPPs data will be created and analyzed using customized tools. 
+In most cases, OCDS for PPPs data will be created and analyzed using customized tools.
 
-However, as a proof-of-concept - and to demonstrate the flattened serialization of the data model - we have prepared a spreadsheet template that can be used to provide detailed disclosures for a PPP project. 
+However, as a proof-of-concept - and to demonstrate the flattened serialization of the data model - we have prepared a spreadsheet template that can be used to provide detailed disclosures for a PPP project.
 
-The template is [available to view via Google Sheets here](https://docs.google.com/spreadsheets/d/1kQSit3fUcyuCN48C9HeIEnrBzbO9sPDj2NUS-8c8VRk/edit#gid=159397949) or [you can take your own copy to edit](https://docs.google.com/spreadsheets/d/1kQSit3fUcyuCN48C9HeIEnrBzbO9sPDj2NUS-8c8VRk/copy). 
+The template is available to [view via Google Sheets](https://docs.google.com/spreadsheets/d/18fPWX7j393XaH-56COco1JoJbduqFqV__siWT3DsHnY/view) or [you can make a copy to edit](https://docs.google.com/spreadsheets/d/18fPWX7j393XaH-56COco1JoJbduqFqV__siWT3DsHnY/copy).
 
 ```{image} _static/images/spreadsheet_template.png
-:target: https://docs.google.com/spreadsheets/d/1kQSit3fUcyuCN48C9HeIEnrBzbO9sPDj2NUS-8c8VRk/edit#gid=159397949
+:target: https://docs.google.com/spreadsheets/d/18fPWX7j393XaH-56COco1JoJbduqFqV__siWT3DsHnY/view
 ```
 
 Unlike the [framework reference](framework.md) which reflects the ordering of properties required by the World Bank PPP Disclosure Framework, the spreadsheet template is structured around the stages of a **contracting process**. 
 
-This means it can also be a useful tool for implementers to think about the points in time at which information will become available. 
+This means it can also be a useful tool for implementers to think about the points in time at which information will become available.
 
-The table structures and validation in the template can also be used to construct smaller data collection tools: for example, monthly metrics reporting sheets. 
+The table structures and validation in the template can also be used to construct smaller data collection tools: for example, monthly metrics reporting sheets.
 
-Advanced users may wish to consult the [flatten tool spreadsheet designers guide](http://flatten-tool.readthedocs.io/en/latest/unflatten/) which explains the syntax used in column headings (row 5) to map between the structured JSON model of OCDS for PPPs, and tabular data. 
+Advanced users may wish to consult the [flatten tool spreadsheet designers guide](http://flatten-tool.readthedocs.io/en/latest/unflatten/) which explains the syntax used in column headings (row 5) to map between the structured JSON model of OCDS for PPPs, and tabular data.


### PR DESCRIPTION
Closes #254 

@jpmckinney - I've updated the spreadsheet links in `docs/spreadsheet.md` but I'm unsure how to update links to the worked example in OCDS Show in `docs/example.md`, e.g.

```{image} _static/images/ocds_show.png
:target: https://open-contracting.github.io/ocds-show-ppp/?load=https://raw.githubusercontent.com/open-contracting/ocds-show-ppp/master/example/full.json
```

It looks like these are broken in `1.0-dev` since the examples were removed from https://github.com/open-contracting/ocds-show-ppp.
